### PR TITLE
Fix NPS survey responses migration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nps_surveys (0.2.3)
+    nps_surveys (0.2.4)
       foreigner
       rails
 
@@ -114,7 +114,7 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (0.3.49)
+    tzinfo (0.3.51)
 
 PLATFORMS
   ruby

--- a/db/migrate/20160614145840_create_nps_survey_responses.rb
+++ b/db/migrate/20160614145840_create_nps_survey_responses.rb
@@ -1,4 +1,4 @@
-class CreateNpsSurveyResponses < ActiveRecord::Migration
+class CreateNPSSurveyResponses < ActiveRecord::Migration
   def change
     create_table :nps_surveys_responses do |t|
       t.string :survey, null: false

--- a/lib/nps_surveys/version.rb
+++ b/lib/nps_surveys/version.rb
@@ -1,3 +1,3 @@
 module NPSSurveys
-  VERSION = '0.2.3'.freeze
+  VERSION = '0.2.4'.freeze
 end


### PR DESCRIPTION
## WHA
Changed class name `CreateNpsSurveyResponses` to `CreateNPSSurveyResponses`.

## WHY
* It was breaking naming conventions.
* It was breaking On-Premise. 
```
uninitialized constant CreateNPSSurveyResponses/mnt/data/teambox/releases/1473237850/vendor/bundle/ruby/2.2.0/gems/activesupport-3.2.22.3/lib/active_support/inflector/methods.rb:230:in `block in constantize'
```
* It was breaking my heart. :cry: 

## GIF
![](https://media.giphy.com/media/x5eW0v9MwldMk/giphy.gif)