### PR TITLE
Replace deprecated #set_table_name with #table_name=

### DIFF
--- a/app/models/nps_surveys/response.rb
+++ b/app/models/nps_surveys/response.rb
@@ -1,7 +1,7 @@
 module NPSSurveys
   class Response < ActiveRecord::Base
 
-    set_table_name NPSSurveys.table_name
+    self.table_name = NPSSurveys.table_name
 
     validates :survey, presence: true
     validates :user_id, presence: true

--- a/lib/nps_surveys/version.rb
+++ b/lib/nps_surveys/version.rb
@@ -1,3 +1,3 @@
 module NPSSurveys
-  VERSION = '0.2.4'.freeze
+  VERSION = '0.2.5'.freeze
 end


### PR DESCRIPTION
I got an `undefined method` when upgrading to Rails 4.0.

According to Rails 3.2 release notes, `set_table_name` is deprecated in favour of `self.table_name=`.